### PR TITLE
check bindingSet is not empty, before get first element.

### DIFF
--- a/src/main/java/eionet/cr/dao/virtuoso/VirtuosoSourceDeletionsDAO.java
+++ b/src/main/java/eionet/cr/dao/virtuoso/VirtuosoSourceDeletionsDAO.java
@@ -196,6 +196,9 @@ public class VirtuosoSourceDeletionsDAO extends VirtuosoBaseDAO implements Sourc
                 if (CollectionUtils.isNotEmpty(bindingNames)) {
                     while (tupleQueryResult.hasNext()) {
                         BindingSet bindingSet = tupleQueryResult.next();
+                        if (CollectionUtils.isNotEmpty(bindingSet)) {
+                            continue;
+                        }
                         Value firstColumnValue = bindingSet.iterator().next().getValue();
                         if (firstColumnValue instanceof URI) {
 


### PR DESCRIPTION
The current implementation does not include a check to verify if the "bindingSet" is empty before invoking the bindingSet.iterator().next() method. This can result in a NoSuchElementException if the "bindingSet" is empty, leading to unexpected errors or exceptions.

![image](https://github.com/eea/eionet.contreg/assets/163422483/76b6799a-7a67-44cb-a696-a8469f1c6613)
